### PR TITLE
Use promise instead of callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 
 
-Convert mov file to mp4 
+Convert mov file to mp4
 
 ## Installation
 
@@ -30,11 +30,12 @@ import MovToMp4 from 'react-native-mov-to-mp4';
 ## Usage:
 ```javascript
             var filename = Date.now().toString();
-            MovToMp4.convertMovToMp4(data.path, filename + ".mp4", function (results) {
-              //here you can upload the video...
-              console.log(results);
-            });
-          
+            MovToMp4.convertMovToMp4(data.path, filename + ".mp4")
+              .then(function (results) {
+                //here you can upload the video...
+                console.log(results);
+              });
+
   ```
 ## Example
 this example use react-native-camera
@@ -64,10 +65,11 @@ render() {
       this.camera.capture()
           .then((data) => {
             var filename = Date.now().toString();
-            MovToMp4.convertMovToMp4(data.path, filename + ".mp4", function (results) {
-              //here you can upload the video...
-              console.log(results);
-            });
+            return MovToMp4.convertMovToMp4(data.path, filename + ".mp4");
+          })
+          .then(function (results) {
+            //here you can upload the video...
+            console.log(results);
           })
           .catch(err => console.error(err));
     }

--- a/movToMp4.ios.js
+++ b/movToMp4.ios.js
@@ -2,16 +2,16 @@
  * @providesModule movToMp4
  * @flow
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component, PropTypes } from "react";
 import {
-    DeviceEventEmitter, // android
-    NativeAppEventEmitter, // ios
-    NativeModules,
-    Platform,
-    StyleSheet,
-    requireNativeComponent,
-    View,
-} from 'react-native';
+  DeviceEventEmitter, // android
+  NativeAppEventEmitter, // ios
+  NativeModules,
+  Platform,
+  StyleSheet,
+  requireNativeComponent,
+  View
+} from "react-native";
 
 //var NativemovToMp4 = require('NativeModules').movToMp4;
 var NativemovToMp4 = NativeModules.movToMp4;
@@ -20,8 +20,8 @@ var NativemovToMp4 = NativeModules.movToMp4;
  */
 
 var movToMp4 = {
-  convertMovToMp4: function(filename, dest, cb) {
-    NativemovToMp4.convertMovToMp4(filename, dest, cb);
+  convertMovToMp4: function(filename, dest) {
+    return NativemovToMp4.convertMovToMp4(filename, dest);
   }
 };
 

--- a/movToMp4.m
+++ b/movToMp4.m
@@ -12,7 +12,8 @@ RCT_EXPORT_MODULE()
 
 RCT_EXPORT_METHOD(convertMovToMp4: (NSString*)filename
                   toPath:(NSString*)outputPath
-                   callback:(RCTResponseSenderBlock)successCallback)
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
 {
     // Your implementation here
 
@@ -33,7 +34,7 @@ RCT_EXPORT_METHOD(convertMovToMp4: (NSString*)filename
                                   exportPresetsCompatibleWithAsset:avAsset];
     AVAssetExportSession *exportSession = [[AVAssetExportSession alloc]initWithAsset:avAsset presetName:AVAssetExportPresetHighestQuality];
     //AVAssetExportPresetMediumQuality
-
+    NSString* domain = @"MovToMp4";
     NSString* documentsDirectory=[NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) objectAtIndex:0];
     exportSession.outputURL = ouputURL2;
     //set the output file format if you want to make it in other file format (ex .3gp)
@@ -44,20 +45,30 @@ RCT_EXPORT_METHOD(convertMovToMp4: (NSString*)filename
         switch ([exportSession status])
         {
             case AVAssetExportSessionStatusFailed:
-                NSLog(@"Export session failed");
+            {
+                NSError *error = [NSError errorWithDomain:domain code: -90 userInfo:nil];
+                reject(@"Failed", @"Export session failed", error);
                 break;
+            }
             case AVAssetExportSessionStatusCancelled:
-                NSLog(@"Export canceled");
+            {
+                NSError *error = [NSError errorWithDomain:domain code: -91 userInfo:nil];
+                reject(@"Cancelled", @"Export canceled", error);
                 break;
+            }
             case AVAssetExportSessionStatusCompleted:
             {
                 //Video conversion finished
                 //NSLog(@"Successful!");
-                successCallback(@[newFile]);
+                resolve(@[newFile]);
             }
                 break;
             default:
+            {
+                NSError *error = [NSError errorWithDomain:domain code: -91 userInfo:nil];
+                reject(@"Unknown", @"Unknown status", error);
                 break;
+            }
         }
     }];
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-mov-to-mp4",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "React Native convert mov files to mp4",
   "main": "movToMp4.ios.js",
   "repository": {


### PR DESCRIPTION
I made an attempt to return a promise instead of relying on a callback. I did this so that I could get an error if the conversion failed. This works in my project, and because I was passing in an invalid path (LOL), I've verified that it does return a rejected promise correctly where there's an error. I don't know enough about the native side to figure out if there's a way to return the actual error, but that would certainly be helpful. Let me know if this is worthwhile.

Oh, I just bumped the minor patch version to make it look like a newer version, but this is certainly a breaking change.

Thanks!