### PR TITLE
Return actual error when rejecting promise

### DIFF
--- a/movToMp4.m
+++ b/movToMp4.m
@@ -46,8 +46,9 @@ RCT_EXPORT_METHOD(convertMovToMp4: (NSString*)filename
         {
             case AVAssetExportSessionStatusFailed:
             {
-                NSError *error = [NSError errorWithDomain:domain code: -90 userInfo:nil];
-                reject(@"Failed", @"Export session failed", error);
+                NSError* error = exportSession.error;
+                NSString *codeWithDomain = [NSString stringWithFormat:@"E%@%zd", error.domain.uppercaseString, error.code];
+                reject(codeWithDomain, error.localizedDescription, error);
                 break;
             }
             case AVAssetExportSessionStatusCancelled:
@@ -58,11 +59,9 @@ RCT_EXPORT_METHOD(convertMovToMp4: (NSString*)filename
             }
             case AVAssetExportSessionStatusCompleted:
             {
-                //Video conversion finished
-                //NSLog(@"Successful!");
                 resolve(@[newFile]);
-            }
                 break;
+            }
             default:
             {
                 NSError *error = [NSError errorWithDomain:domain code: -91 userInfo:nil];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-mov-to-mp4",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "React Native convert mov files to mp4",
   "main": "movToMp4.ios.js",
   "repository": {


### PR DESCRIPTION
This returns the actual error generated when the conversion process fails.  The description isn't that great, but I think that's a fault of the actual error.